### PR TITLE
Making reparam an instance method in SumLayer and ExponentialFamilyArray classes

### DIFF
--- a/src/EinsumNetwork/ExponentialFamilyArray.py
+++ b/src/EinsumNetwork/ExponentialFamilyArray.py
@@ -75,11 +75,11 @@ class ExponentialFamilyArray(torch.nn.Module):
         self._online_em_stepsize = None
         self._online_em_counter = 0
 
-        # if em is switched off, we re-parametrize the expectation parameters
-        # self.reparam holds the function object for this task
-        self.reparam = None
-        if not self._use_em:
-            self.reparam = self.reparam_function()
+        # # if em is switched off, we re-parametrize the expectation parameters
+        # # self.reparam holds the function object for this task
+        # self.reparam = None
+        # if not self._use_em:
+        #     self.reparam = self.reparam_function()
 
     # --------------------------------------------------------------------------------
     # The following functions need to be implemented to specify an exponential family.
@@ -151,16 +151,29 @@ class ExponentialFamilyArray(torch.nn.Module):
         """
         raise NotImplementedError
 
-    def reparam_function(self):
+    # def reparam_function(self):
+    #     """
+    #     Re-parameterize parameters, in order that they stay in their constrained domain.
+
+    #     When we are not using the EM, we need to transform unconstrained (real-valued) parameters to the constrained set
+    #     of the expectation parameter. This function should return such a function (i.e. the return value should not be
+    #     a projection, but a function which does the projection).
+
+    #     :return: function object f which takes as input unconstrained parameters (Tensor) and returns re-parametrized
+    #              parameters.
+    #     """
+    #     raise NotImplementedError
+    def reparam(self, params):
         """
         Re-parameterize parameters, in order that they stay in their constrained domain.
 
         When we are not using the EM, we need to transform unconstrained (real-valued) parameters to the constrained set
-        of the expectation parameter. This function should return such a function (i.e. the return value should not be
+        of the expectation parameter.
+        This function should return such a function (i.e. the return value should not be
         a projection, but a function which does the projection).
 
-        :return: function object f which takes as input unconstrained parameters (Tensor) and returns re-parametrized
-                 parameters.
+        :param params: unconstrained parameters (Tensor) to be projected
+        :return: re-parametrized parameters.
         """
         raise NotImplementedError
 
@@ -406,12 +419,16 @@ class NormalArray(ExponentialFamilyArray):
         phi_project[..., self.num_dims:] += mu2
         return phi_project
 
-    def reparam_function(self):
-        def reparam(params_in):
-            mu = params_in[..., 0:self.num_dims].clone()
-            var = self.min_var + torch.sigmoid(params_in[..., self.num_dims:]) * (self.max_var - self.min_var)
-            return torch.cat((mu, var + mu**2), -1)
-        return reparam
+    def reparam(self, params_in):
+        mu = params_in[..., 0:self.num_dims].clone()
+        var = self.min_var + torch.sigmoid(params_in[..., self.num_dims:]) * (self.max_var - self.min_var)
+        return torch.cat((mu, var + mu**2), -1)
+    # def reparam_function(self):
+    #     def reparam(params_in):
+    #         mu = params_in[..., 0:self.num_dims].clone()
+    #         var = self.min_var + torch.sigmoid(params_in[..., self.num_dims:]) * (self.max_var - self.min_var)
+    #         return torch.cat((mu, var + mu**2), -1)
+    #     return reparam
 
     def sufficient_statistics(self, x):
         if len(x.shape) == 2:
@@ -465,10 +482,12 @@ class BinomialArray(ExponentialFamilyArray):
     def project_params(self, phi):
         return torch.clamp(phi, 0.0, self.N)
 
-    def reparam_function(self):
-        def reparam(params):
-            return torch.sigmoid(params * 0.1) * float(self.N)
-        return reparam
+    def reparam(self, params):
+        return torch.sigmoid(params * 0.1) * float(self.N)
+    # def reparam_function(self):
+    #     def reparam(params):
+    #         return torch.sigmoid(params * 0.1) * float(self.N)
+    #     return reparam
 
     def sufficient_statistics(self, x):
         if len(x.shape) == 2:
@@ -534,10 +553,12 @@ class CategoricalArray(ExponentialFamilyArray):
         phi = phi / torch.sum(phi, -1, keepdim=True)
         return phi.reshape(self.num_var, *self.array_shape, self.num_dims * self.K)
 
-    def reparam_function(self):
-        def reparam(params):
-            return torch.nn.functional.softmax(params, -1)
-        return reparam
+    def reparam(self, params):
+        return torch.nn.functional.softmax(params, -1)
+    # def reparam_function(self):
+    #     def reparam(params):
+    #         return torch.nn.functional.softmax(params, -1)
+    #     return reparam
 
     def sufficient_statistics(self, x):
         if len(x.shape) == 2:

--- a/src/EinsumNetwork/ExponentialFamilyArray.py
+++ b/src/EinsumNetwork/ExponentialFamilyArray.py
@@ -75,12 +75,6 @@ class ExponentialFamilyArray(torch.nn.Module):
         self._online_em_stepsize = None
         self._online_em_counter = 0
 
-        # # if em is switched off, we re-parametrize the expectation parameters
-        # # self.reparam holds the function object for this task
-        # self.reparam = None
-        # if not self._use_em:
-        #     self.reparam = self.reparam_function()
-
     # --------------------------------------------------------------------------------
     # The following functions need to be implemented to specify an exponential family.
 
@@ -151,18 +145,6 @@ class ExponentialFamilyArray(torch.nn.Module):
         """
         raise NotImplementedError
 
-    # def reparam_function(self):
-    #     """
-    #     Re-parameterize parameters, in order that they stay in their constrained domain.
-
-    #     When we are not using the EM, we need to transform unconstrained (real-valued) parameters to the constrained set
-    #     of the expectation parameter. This function should return such a function (i.e. the return value should not be
-    #     a projection, but a function which does the projection).
-
-    #     :return: function object f which takes as input unconstrained parameters (Tensor) and returns re-parametrized
-    #              parameters.
-    #     """
-    #     raise NotImplementedError
     def reparam(self, params):
         """
         Re-parameterize parameters, in order that they stay in their constrained domain.
@@ -423,12 +405,6 @@ class NormalArray(ExponentialFamilyArray):
         mu = params_in[..., 0:self.num_dims].clone()
         var = self.min_var + torch.sigmoid(params_in[..., self.num_dims:]) * (self.max_var - self.min_var)
         return torch.cat((mu, var + mu**2), -1)
-    # def reparam_function(self):
-    #     def reparam(params_in):
-    #         mu = params_in[..., 0:self.num_dims].clone()
-    #         var = self.min_var + torch.sigmoid(params_in[..., self.num_dims:]) * (self.max_var - self.min_var)
-    #         return torch.cat((mu, var + mu**2), -1)
-    #     return reparam
 
     def sufficient_statistics(self, x):
         if len(x.shape) == 2:
@@ -484,10 +460,6 @@ class BinomialArray(ExponentialFamilyArray):
 
     def reparam(self, params):
         return torch.sigmoid(params * 0.1) * float(self.N)
-    # def reparam_function(self):
-    #     def reparam(params):
-    #         return torch.sigmoid(params * 0.1) * float(self.N)
-    #     return reparam
 
     def sufficient_statistics(self, x):
         if len(x.shape) == 2:
@@ -555,10 +527,6 @@ class CategoricalArray(ExponentialFamilyArray):
 
     def reparam(self, params):
         return torch.nn.functional.softmax(params, -1)
-    # def reparam_function(self):
-    #     def reparam(params):
-    #         return torch.nn.functional.softmax(params, -1)
-    #     return reparam
 
     def sufficient_statistics(self, x):
         if len(x.shape) == 2:

--- a/src/EinsumNetwork/FactorizedLeafLayer.py
+++ b/src/EinsumNetwork/FactorizedLeafLayer.py
@@ -145,9 +145,6 @@ class FactorizedLeafLayer(Layer):
     def project_params(self, params):
         self.ef_array.project_params(params)
 
-        
-    # def reparam_function(self):
-    #     return self.ef_array.reparam_function()
     def reparam(self, params):
         return self.ef_array.reparam(params)
 

--- a/src/EinsumNetwork/FactorizedLeafLayer.py
+++ b/src/EinsumNetwork/FactorizedLeafLayer.py
@@ -145,8 +145,11 @@ class FactorizedLeafLayer(Layer):
     def project_params(self, params):
         self.ef_array.project_params(params)
 
-    def reparam_function(self):
-        return self.ef_array.reparam_function()
+        
+    # def reparam_function(self):
+    #     return self.ef_array.reparam_function()
+    def reparam(self, params):
+        return self.ef_array.reparam(params)
 
     # --------------------------------------------------------------------------------
 

--- a/src/EinsumNetwork/SumLayer.py
+++ b/src/EinsumNetwork/SumLayer.py
@@ -34,11 +34,6 @@ class SumLayer(Layer):
         self.online_em_stepsize = None
         self._online_em_counter = 0
 
-        # # if EM is not used, we reparametrize
-        # self.reparam = None
-        # if not self._use_em:
-        #     self.reparam = self.reparam_function()
-
     # --------------------------------------------------------------------------------
     # The following functions need to be implemented in derived classes.
 
@@ -215,28 +210,6 @@ class SumLayer(Layer):
         out = softmax(params_in, -1)
         out = out.reshape(orig_shape).permute(unpermutation)
         return out
-
-    # def reparam_function(self):
-    #     """
-    #     Reparametrization function, transforming unconstrained parameters into valid sum-weight
-    #     (non-negative, normalized).
-    #     """
-    #     def reparam(params_in):
-    #         other_dims = tuple(i for i in range(len(params_in.shape)) if i not in self.normalization_dims)
-
-    #         permutation = other_dims + self.normalization_dims
-    #         unpermutation = tuple(c for i in range(len(permutation)) for c, j in enumerate(permutation) if j == i)
-
-    #         numel = functools.reduce(lambda x, y: x * y, [params_in.shape[i] for i in self.normalization_dims])
-
-    #         other_shape = tuple(params_in.shape[i] for i in other_dims)
-    #         params_in = params_in.permute(permutation)
-    #         orig_shape = params_in.shape
-    #         params_in = params_in.reshape(other_shape + (numel,))
-    #         out = softmax(params_in, -1)
-    #         out = out.reshape(orig_shape).permute(unpermutation)
-    #         return out
-    #     return reparam
 
     def project_params(self, params):
         """Currently not required."""

--- a/src/EinsumNetwork/SumLayer.py
+++ b/src/EinsumNetwork/SumLayer.py
@@ -34,10 +34,10 @@ class SumLayer(Layer):
         self.online_em_stepsize = None
         self._online_em_counter = 0
 
-        # if EM is not used, we reparametrize
-        self.reparam = None
-        if not self._use_em:
-            self.reparam = self.reparam_function()
+        # # if EM is not used, we reparametrize
+        # self.reparam = None
+        # if not self._use_em:
+        #     self.reparam = self.reparam_function()
 
     # --------------------------------------------------------------------------------
     # The following functions need to be implemented in derived classes.
@@ -193,27 +193,50 @@ class SumLayer(Layer):
             self.params.data = self.params / (self.params.sum(self.normalization_dims, keepdim=True))
             self.params.grad = None
 
-    def reparam_function(self):
+    def reparam(self, params_in):
         """
         Reparametrization function, transforming unconstrained parameters into valid sum-weight
         (non-negative, normalized).
+
+        :params_in params: unconstrained parameters (Tensor) to be projected
+        :return: re-parametrized parameters.
         """
-        def reparam(params_in):
-            other_dims = tuple(i for i in range(len(params_in.shape)) if i not in self.normalization_dims)
+        other_dims = tuple(i for i in range(len(params_in.shape)) if i not in self.normalization_dims)
 
-            permutation = other_dims + self.normalization_dims
-            unpermutation = tuple(c for i in range(len(permutation)) for c, j in enumerate(permutation) if j == i)
+        permutation = other_dims + self.normalization_dims
+        unpermutation = tuple(c for i in range(len(permutation)) for c, j in enumerate(permutation) if j == i)
 
-            numel = functools.reduce(lambda x, y: x * y, [params_in.shape[i] for i in self.normalization_dims])
+        numel = functools.reduce(lambda x, y: x * y, [params_in.shape[i] for i in self.normalization_dims])
 
-            other_shape = tuple(params_in.shape[i] for i in other_dims)
-            params_in = params_in.permute(permutation)
-            orig_shape = params_in.shape
-            params_in = params_in.reshape(other_shape + (numel,))
-            out = softmax(params_in, -1)
-            out = out.reshape(orig_shape).permute(unpermutation)
-            return out
-        return reparam
+        other_shape = tuple(params_in.shape[i] for i in other_dims)
+        params_in = params_in.permute(permutation)
+        orig_shape = params_in.shape
+        params_in = params_in.reshape(other_shape + (numel,))
+        out = softmax(params_in, -1)
+        out = out.reshape(orig_shape).permute(unpermutation)
+        return out
+
+    # def reparam_function(self):
+    #     """
+    #     Reparametrization function, transforming unconstrained parameters into valid sum-weight
+    #     (non-negative, normalized).
+    #     """
+    #     def reparam(params_in):
+    #         other_dims = tuple(i for i in range(len(params_in.shape)) if i not in self.normalization_dims)
+
+    #         permutation = other_dims + self.normalization_dims
+    #         unpermutation = tuple(c for i in range(len(permutation)) for c, j in enumerate(permutation) if j == i)
+
+    #         numel = functools.reduce(lambda x, y: x * y, [params_in.shape[i] for i in self.normalization_dims])
+
+    #         other_shape = tuple(params_in.shape[i] for i in other_dims)
+    #         params_in = params_in.permute(permutation)
+    #         orig_shape = params_in.shape
+    #         params_in = params_in.reshape(other_shape + (numel,))
+    #         out = softmax(params_in, -1)
+    #         out = out.reshape(orig_shape).permute(unpermutation)
+    #         return out
+    #     return reparam
 
     def project_params(self, params):
         """Currently not required."""

--- a/test/test_load_save.py
+++ b/test/test_load_save.py
@@ -138,42 +138,22 @@ def load_einet_state(model_path,
         
     return einet, graph
 
+def check_einets_eq(e1, e2):
+    assert len(e1.einet_layers) == len(e2.einet_layers)
+    for l, l_p  in zip(e1.einet_layers, e2.einet_layers):
+        if hasattr(l, "params"):
+            assert torch.all(torch.eq(l.params, l_p.params))
+
 
 classes = [7]
-# classes = [2, 3, 5, 7]
-# classes = None
-
-# K = 10
-
-# structure = 'poon-domingos'
-# structure = 'binary-trees'
-
-# 'poon-domingos'
-# pd_num_pieces = [4]
-# pd_num_pieces = [7]
-# pd_num_pieces = [7, 28]
-# width = 28
-# height = 28
-
-# 'binary-trees'
-# depth = 3
-# num_repetitions = 20
-
 num_epochs = 5
 batch_size = 100
-# online_em_frequency = 1
-# online_em_stepsize = 0.05
+
 ############################################################################
 
 
 # get data
 train_x, train_labels, test_x, test_labels = datasets.load_mnist()
-
-# if not exponential_family != EinsumNetwork.NormalArray:
-#     train_x /= 255.
-#     test_x /= 255.
-#     train_x -= .5
-#     test_x -= .5
 
 # validation split
 valid_x = train_x[-10000:, :]
@@ -232,7 +212,7 @@ print("pre-train   train LL {}   valid LL {}   test LL {}".format(
 
 ######################################
 # Save untrained
-
+#
 # out_path = './saved-pretrained-state'
 # save_einet_state(einet, rg, out_path=out_path)
 # einet_p, graph_p = load_einet_state(out_path, graph=rg,
@@ -250,6 +230,9 @@ save_einet(einet, rg, out_path=out_path)
 einet_p, graph_p = load_einet(out_path)
 
 
+##### check same model
+check_einets_eq(einet, einet_p)
+print("Einets equal")
 
 ##### evaluate
 einet_p.eval()
@@ -312,6 +295,10 @@ print("post-training (before saving) --- train LL {}   valid LL {}   test LL {}"
 
 save_einet(einet, rg, out_path=out_path)
 einet_p, graph_p = load_einet(out_path)
+
+##### check same model
+check_einets_eq(einet, einet_p)
+print("Einets equal")
 
 ##### evaluate
 einet_p.eval()

--- a/test/test_load_save.py
+++ b/test/test_load_save.py
@@ -191,6 +191,8 @@ train_x = torch.from_numpy(train_x).to(torch.device(device))
 valid_x = torch.from_numpy(valid_x).to(torch.device(device))
 test_x = torch.from_numpy(test_x).to(torch.device(device))
 
+
+use_em = False
 rg = make_region_graph(structure="poon-domingos",
                       height=28, width=28,
                       pd_pieces=[4], depth=None, n_repetitions=None)
@@ -200,7 +202,7 @@ einet = make_einet(region_graph=rg,
                n_sums=10,
                n_input_dists=10,
                exp_fam="binomial", exp_fam_args={'N': 255},
-               use_em=False,
+               use_em=use_em,
                # em_freq=1, em_stepsize=0.05
                em_freq=None, em_stepsize=None
                )
@@ -231,21 +233,23 @@ print("pre-train   train LL {}   valid LL {}   test LL {}".format(
 ######################################
 # Save untrained
 
-out_path = './saved-pretrained-state'
-save_einet_state(einet, rg, out_path=out_path)
-einet_p, graph_p = load_einet_state(out_path, graph=rg,
-                                    n_vars=28*28,
-               n_classes=1,
-               n_sums=10,
-               n_input_dists=10,
-               exp_fam="binomial", exp_fam_args={'N': 255},
-               use_em=False,
-               # em_freq=1, em_stepsize=0.05
-               em_freq=None, em_stepsize=None)
+# out_path = './saved-pretrained-state'
+# save_einet_state(einet, rg, out_path=out_path)
+# einet_p, graph_p = load_einet_state(out_path, graph=rg,
+#                                     n_vars=28*28,
+#                n_classes=1,
+#                n_sums=10,
+#                n_input_dists=10,
+#                exp_fam="binomial", exp_fam_args={'N': 255},
+#                use_em=False,
+#                # em_freq=1, em_stepsize=0.05
+#                em_freq=None, em_stepsize=None)
 
-# out_path = './saved-pretrained'
-# save_einet(einet, rg, out_path=out_path)
-# einet_p, graph_p = load_einet(out_path)
+out_path = './saved-pretrained'
+save_einet(einet, rg, out_path=out_path)
+einet_p, graph_p = load_einet(out_path)
+
+
 
 ##### evaluate
 einet_p.eval()
@@ -257,46 +261,65 @@ print("pre-train (after loading)   train LL {}   valid LL {}   test LL {}".forma
     valid_ll / valid_N,
     test_ll / test_N))
 
-0/0
 
-einet.train()
 #####
+einet.train()
 
-idx_batches = torch.randperm(train_N, device=device).split(batch_size)
+optimizer = None
+if not use_em:
+    optimizer = torch.optim.Adam(einet.parameters(), lr=1e-2)
 
-total_ll = 0.0
-for idx in idx_batches:
-    batch_x = train_x[idx, :]
-    outputs = einet.forward(batch_x)
-    ll_sample = EinsumNetwork.log_likelihoods(outputs)
-    log_likelihood = ll_sample.sum()
-    log_likelihood.backward()
+n_epochs = 5
+for epoch in range(n_epochs):
+    idx_batches = torch.randperm(train_N, device=device).split(batch_size)
 
-    einet.em_process_batch()
-    total_ll += log_likelihood.detach().item()
+    total_ll = 0.0
+    for idx in idx_batches:
+        batch_x = train_x[idx, :]
+        outputs = einet.forward(batch_x)
+        ll_sample = EinsumNetwork.log_likelihoods(outputs)
+        log_likelihood = ll_sample.sum()
+        
 
-einet.em_update()
+        if use_em:
+            log_likelihood.backward()
+            einet.em_process_batch()
+        else:
+            optimizer.zero_grad()
+            objective = -log_likelihood
+            objective.backward()
+            optimizer.step()
+            
+        total_ll += log_likelihood.detach().item()
+    print(f"done epoch {epoch+1}/{n_epochs}")
+
+    if use_em:
+        einet.em_update()
 
 
 # evaluate log-likelihoods
 einet.eval()
-train_ll_before = EinsumNetwork.eval_loglikelihood_batched(einet, train_x, batch_size=batch_size)
-valid_ll_before = EinsumNetwork.eval_loglikelihood_batched(einet, valid_x, batch_size=batch_size)
-test_ll_before = EinsumNetwork.eval_loglikelihood_batched(einet, test_x, batch_size=batch_size)
-
-
-
-
 # evaluate log-likelihoods on re-loaded model
 train_ll = EinsumNetwork.eval_loglikelihood_batched(einet, train_x, batch_size=batch_size)
 valid_ll = EinsumNetwork.eval_loglikelihood_batched(einet, valid_x, batch_size=batch_size)
 test_ll = EinsumNetwork.eval_loglikelihood_batched(einet, test_x, batch_size=batch_size)
 print()
-print("Log-likelihoods before saving --- train LL {}   valid LL {}   test LL {}".format(
+print("post-training (before saving) --- train LL {}   valid LL {}   test LL {}".format(
         train_ll / train_N,
         valid_ll / valid_N,
         test_ll / test_N))
-print("Log-likelihoods after saving  --- train LL {}   valid LL {}   test LL {}".format(
-        train_ll / train_N,
-        valid_ll / valid_N,
-        test_ll / test_N))
+
+
+save_einet(einet, rg, out_path=out_path)
+einet_p, graph_p = load_einet(out_path)
+
+##### evaluate
+einet_p.eval()
+train_ll = EinsumNetwork.eval_loglikelihood_batched(einet_p, train_x, batch_size=batch_size)
+valid_ll = EinsumNetwork.eval_loglikelihood_batched(einet_p, valid_x, batch_size=batch_size)
+test_ll = EinsumNetwork.eval_loglikelihood_batched(einet_p, test_x, batch_size=batch_size)
+print("pre-train (after re-loading)   train LL {}   valid LL {}   test LL {}".format(
+    train_ll / train_N,
+    valid_ll / valid_N,
+    test_ll / test_N))
+

--- a/test/test_load_save.py
+++ b/test/test_load_save.py
@@ -1,0 +1,302 @@
+import os
+import sys
+
+import numpy as np
+import torch
+
+sys.path.append("../src")
+from EinsumNetwork import Graph, EinsumNetwork
+import datasets
+import utils
+
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+demo_text = """
+This scripts loads mnist, trains an EiNet for one epoch, saves it to disk, then reloads it. 
+"""
+print(demo_text)
+
+# Make EinsumNetwork
+######################################
+
+def make_region_graph(structure="poon-domingos",
+                      height=None, width=None,
+                      pd_pieces=None, depth=None, n_repetitions=None):
+
+    
+    graph = None
+    if structure == 'poon-domingos':
+        assert pd_pieces is not None
+        pd_delta = [[height / d, width / d] for d in pd_pieces]
+        graph = Graph.poon_domingos_structure(shape=(height, width), delta=pd_delta)
+    elif structure == 'binary-trees':
+        n_vars = height * width
+        graph = Graph.random_binary_trees(num_var=n_vars,
+                                          depth=depth,
+                                          num_repetitions=n_repetitions)
+    else:
+        raise AssertionError("Unknown Structure")
+
+    return graph
+
+def make_einet(region_graph,
+               n_vars,
+               n_classes=1,
+               n_sums=10,
+               n_input_dists=10,
+               exp_fam="binomial", exp_fam_args={'N': 255},
+               use_em=False,
+               em_freq=None, em_stepsize=None):
+
+    if exp_fam == "binomial":
+        exponential_family = EinsumNetwork.BinomialArray
+    elif exp_fam == "categorical":
+        exponential_family = EinsumNetwork.CategoricalArray
+    else:
+        raise ValueError(f"Unrecognized exponential family: {exp_fam}")
+
+    args = EinsumNetwork.Args(
+        num_var=n_vars,
+        num_dims=1,
+        num_classes=n_classes,
+        num_sums=n_sums,
+        num_input_distributions=n_input_dists,
+        exponential_family=exponential_family,
+        exponential_family_args=exp_fam_args,
+        use_em=use_em,
+        online_em_frequency=em_freq,
+        online_em_stepsize=em_stepsize)
+
+    einet = EinsumNetwork.EinsumNetwork(region_graph, args)
+    return einet
+
+def save_einet(einet, graph, out_path):
+    # save model
+    os.makedirs(out_path, exist_ok=True)
+    graph_file = os.path.join(out_path, "einet.rg")
+    Graph.write_gpickle(graph, graph_file)
+    print("Saved PC graph to {}".format(graph_file))
+    model_file = os.path.join(out_path, "einet.pth")
+    torch.save(einet, model_file)
+    print("Saved model to {}".format(model_file))
+
+def save_einet_state(einet, graph, out_path):
+    # save model
+    os.makedirs(out_path, exist_ok=True)
+    # graph_file = os.path.join(out_path, "einet.rg")
+    # Graph.write_gpickle(graph, graph_file)
+    # print("Saved PC graph to {}".format(graph_file))
+    model_file = os.path.join(out_path, "einet.pth")
+    torch.save(einet.state_dict(), model_file)
+    print("Saved model to {}".format(model_file))
+
+def load_einet(model_path, einet_file='einet.pth', graph_file='einet.rg'):
+
+    # reload model
+    einet, graph = None, None
+    model_file = os.path.join(model_path, einet_file)
+    einet = torch.load(model_file)
+    print("Loaded model from {}".format(model_file))
+    
+    if graph_file:
+        graph_file = os.path.join(model_path, graph_file)
+        graph = Graph.read_gpickle(graph_file)
+        
+    return einet, graph
+
+def load_einet_state(model_path,
+                     einet_file='einet.pth',
+                     graph_file='einet.rg',
+                     n_vars=None, n_classes=None, n_sums=None, n_input_dists=None,
+                     exp_fam=None, exp_fam_args=None,
+                     use_em=None, em_freq=None, em_stepsize=None,
+                     graph=None):
+
+    # reload model
+    einet = None
+
+    if graph is None:
+        if graph_file:
+            graph_file = os.path.join(model_path, graph_file)
+            graph = Graph.read_gpickle(graph_file)
+        else:
+            raise ValueError(f"Cannot create graph")
+    
+    model_file = os.path.join(model_path, einet_file)
+    
+    einet = make_einet(graph,
+               n_vars=n_vars,
+               n_classes=n_classes,
+               n_sums=n_sums,
+               n_input_dists=n_input_dists,
+               exp_fam=exp_fam, exp_fam_args=exp_fam_args,
+               use_em=use_em,
+               em_freq=em_freq, em_stepsize=em_stepsize)
+    einet.load_state_dict(torch.load(model_file))
+    
+    print("Loaded model from {}".format(model_file))
+        
+    return einet, graph
+
+
+classes = [7]
+# classes = [2, 3, 5, 7]
+# classes = None
+
+# K = 10
+
+# structure = 'poon-domingos'
+# structure = 'binary-trees'
+
+# 'poon-domingos'
+# pd_num_pieces = [4]
+# pd_num_pieces = [7]
+# pd_num_pieces = [7, 28]
+# width = 28
+# height = 28
+
+# 'binary-trees'
+# depth = 3
+# num_repetitions = 20
+
+num_epochs = 5
+batch_size = 100
+# online_em_frequency = 1
+# online_em_stepsize = 0.05
+############################################################################
+
+
+# get data
+train_x, train_labels, test_x, test_labels = datasets.load_mnist()
+
+# if not exponential_family != EinsumNetwork.NormalArray:
+#     train_x /= 255.
+#     test_x /= 255.
+#     train_x -= .5
+#     test_x -= .5
+
+# validation split
+valid_x = train_x[-10000:, :]
+train_x = train_x[:-10000, :]
+valid_labels = train_labels[-10000:]
+train_labels = train_labels[:-10000]
+
+# pick the selected classes
+if classes is not None:
+    train_x = train_x[np.any(np.stack([train_labels == c for c in classes], 1), 1), :]
+    valid_x = valid_x[np.any(np.stack([valid_labels == c for c in classes], 1), 1), :]
+    test_x = test_x[np.any(np.stack([test_labels == c for c in classes], 1), 1), :]
+
+train_x = torch.from_numpy(train_x).to(torch.device(device))
+valid_x = torch.from_numpy(valid_x).to(torch.device(device))
+test_x = torch.from_numpy(test_x).to(torch.device(device))
+
+rg = make_region_graph(structure="poon-domingos",
+                      height=28, width=28,
+                      pd_pieces=[4], depth=None, n_repetitions=None)
+einet = make_einet(region_graph=rg,
+               n_vars=28*28,
+               n_classes=1,
+               n_sums=10,
+               n_input_dists=10,
+               exp_fam="binomial", exp_fam_args={'N': 255},
+               use_em=False,
+               # em_freq=1, em_stepsize=0.05
+               em_freq=None, em_stepsize=None
+               )
+einet.initialize()
+einet.to(device)
+print(einet)
+
+
+# Train for one epoch
+######################################
+
+train_N = train_x.shape[0]
+valid_N = valid_x.shape[0]
+test_N = test_x.shape[0]
+
+
+##### evaluate
+einet.eval()
+train_ll = EinsumNetwork.eval_loglikelihood_batched(einet, train_x, batch_size=batch_size)
+valid_ll = EinsumNetwork.eval_loglikelihood_batched(einet, valid_x, batch_size=batch_size)
+test_ll = EinsumNetwork.eval_loglikelihood_batched(einet, test_x, batch_size=batch_size)
+print("pre-train   train LL {}   valid LL {}   test LL {}".format(
+    train_ll / train_N,
+    valid_ll / valid_N,
+    test_ll / test_N))
+
+
+######################################
+# Save untrained
+
+out_path = './saved-pretrained-state'
+save_einet_state(einet, rg, out_path=out_path)
+einet_p, graph_p = load_einet_state(out_path, graph=rg,
+                                    n_vars=28*28,
+               n_classes=1,
+               n_sums=10,
+               n_input_dists=10,
+               exp_fam="binomial", exp_fam_args={'N': 255},
+               use_em=False,
+               # em_freq=1, em_stepsize=0.05
+               em_freq=None, em_stepsize=None)
+
+# out_path = './saved-pretrained'
+# save_einet(einet, rg, out_path=out_path)
+# einet_p, graph_p = load_einet(out_path)
+
+##### evaluate
+einet_p.eval()
+train_ll = EinsumNetwork.eval_loglikelihood_batched(einet_p, train_x, batch_size=batch_size)
+valid_ll = EinsumNetwork.eval_loglikelihood_batched(einet_p, valid_x, batch_size=batch_size)
+test_ll = EinsumNetwork.eval_loglikelihood_batched(einet_p, test_x, batch_size=batch_size)
+print("pre-train (after loading)   train LL {}   valid LL {}   test LL {}".format(
+    train_ll / train_N,
+    valid_ll / valid_N,
+    test_ll / test_N))
+
+0/0
+
+einet.train()
+#####
+
+idx_batches = torch.randperm(train_N, device=device).split(batch_size)
+
+total_ll = 0.0
+for idx in idx_batches:
+    batch_x = train_x[idx, :]
+    outputs = einet.forward(batch_x)
+    ll_sample = EinsumNetwork.log_likelihoods(outputs)
+    log_likelihood = ll_sample.sum()
+    log_likelihood.backward()
+
+    einet.em_process_batch()
+    total_ll += log_likelihood.detach().item()
+
+einet.em_update()
+
+
+# evaluate log-likelihoods
+einet.eval()
+train_ll_before = EinsumNetwork.eval_loglikelihood_batched(einet, train_x, batch_size=batch_size)
+valid_ll_before = EinsumNetwork.eval_loglikelihood_batched(einet, valid_x, batch_size=batch_size)
+test_ll_before = EinsumNetwork.eval_loglikelihood_batched(einet, test_x, batch_size=batch_size)
+
+
+
+
+# evaluate log-likelihoods on re-loaded model
+train_ll = EinsumNetwork.eval_loglikelihood_batched(einet, train_x, batch_size=batch_size)
+valid_ll = EinsumNetwork.eval_loglikelihood_batched(einet, valid_x, batch_size=batch_size)
+test_ll = EinsumNetwork.eval_loglikelihood_batched(einet, test_x, batch_size=batch_size)
+print()
+print("Log-likelihoods before saving --- train LL {}   valid LL {}   test LL {}".format(
+        train_ll / train_N,
+        valid_ll / valid_N,
+        test_ll / test_N))
+print("Log-likelihoods after saving  --- train LL {}   valid LL {}   test LL {}".format(
+        train_ll / train_N,
+        valid_ll / valid_N,
+        test_ll / test_N))


### PR DESCRIPTION
Replacing `reparam_function` with a `reparam` function as a direct instance method, in order to avoid local function objects that cannot be pickled.

See Issue #1