### PR TITLE
Fix missing num_var parameter in suff_stat reshape

### DIFF
--- a/src/EinsumNetwork/ExponentialFamilyArray.py
+++ b/src/EinsumNetwork/ExponentialFamilyArray.py
@@ -543,7 +543,7 @@ class CategoricalArray(ExponentialFamilyArray):
         if len(x.shape) == 2:
             stats = one_hot(x.long(), self.K)
         elif len(x.shape) == 3:
-            stats = one_hot(x.long(), self.K).reshape(-1, self.num_dims * self.K)
+            stats = one_hot(x.long(), self.K).reshape(-1, self.num_var, self.num_dims * self.K)
         else:
             raise AssertionError("Input must be 2 or 3 dimensional tensor.")
         return stats


### PR DESCRIPTION
When the input for `CategoricalArray` was `len(x.shape)==3`, the `reshape` operation for the `stats` variable was missing the `num_var` variable and resulted in a wrong output shape (i.e. the `-1` as first reshape-argument would then merge the batch size and `num_var` into a single dimension).