### PR TITLE
Stop variance from being zero to avoid div. by zero

### DIFF
--- a/src/EinsumNetwork/ExponentialFamilyArray.py
+++ b/src/EinsumNetwork/ExponentialFamilyArray.py
@@ -417,6 +417,7 @@ class NormalArray(ExponentialFamilyArray):
 
     def expectation_to_natural(self, phi):
         var = phi[..., self.num_dims:] - phi[..., 0:self.num_dims] ** 2
+        var = torch.clamp(var, min=self.min_var)
         theta1 = phi[..., 0:self.num_dims] / var
         theta2 = - 1. / (2. * var)
         return torch.cat((theta1, theta2), -1)


### PR DESCRIPTION
Variance in natural parameters can be zero which leads to division by zero issues. The variance can be clamped at the specified/default minimum variance  value.